### PR TITLE
Adds Liveness Probe on prod 1.6.0 workers

### DIFF
--- a/deployments/production/spark-worker-controller.json
+++ b/deployments/production/spark-worker-controller.json
@@ -46,6 +46,18 @@
                         ],
                         "image": "quay.io/winkapp/spark-standalone:master",
                         "imagePullPolicy": "IfNotPresent",
+                        "livenessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/",
+                                "port": 8081,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 10,
+                            "periodSeconds": 30,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 10
+                        },
                         "name": "spark-worker",
                         "ports": [
                             {


### PR DESCRIPTION
adds a liveness probe on the production config for spark v1.6.0 worker controller

with this PR - all worker controllers for 1.6 & 2.1 spark clusters (in either deploy env) have liveness probes that can trigger reaping/re-init