### PR TITLE
History Server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,11 @@ RUN apt-get update; apt-get install -y \
 RUN curl -s http://d3kbcqa49mib13.cloudfront.net/spark-1.6.0-bin-hadoop2.6.tgz | tar -xz -C /usr/local/
 RUN cd /usr/local && ln -s spark-1.6.0-bin-hadoop2.6 spark
 ENV SPARK_HOME /usr/local/spark
+COPY conf /usr/local/spark/conf
+RUN  mkdir /data/spark-events
 ENV PATH $SPARK_HOME/bin:$PATH
 # set the python path explicitly because spark looks in the wrong spot by default
 ENV PYTHONPATH `echo "import sys; print ':'.join(sys.path)" | python`:$PYTHONPATH
 ADD bootstrap.sh /usr/local/bootstrap.sh
-COPY conf /usr/local/spark/conf
 ENTRYPOINT ["/usr/local/bootstrap.sh"]
 WORKDIR /usr/local/spark

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,6 @@ ENV PATH $SPARK_HOME/bin:$PATH
 # set the python path explicitly because spark looks in the wrong spot by default
 ENV PYTHONPATH `echo "import sys; print ':'.join(sys.path)" | python`:$PYTHONPATH
 ADD bootstrap.sh /usr/local/bootstrap.sh
+COPY conf /usr/local/spark/conf
 ENTRYPOINT ["/usr/local/bootstrap.sh"]
 WORKDIR /usr/local/spark

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN curl -s http://d3kbcqa49mib13.cloudfront.net/spark-1.6.0-bin-hadoop2.6.tgz |
 RUN cd /usr/local && ln -s spark-1.6.0-bin-hadoop2.6 spark
 ENV SPARK_HOME /usr/local/spark
 COPY conf /usr/local/spark/conf
-RUN  mkdir /data/spark-events
+RUN  mkdir -p /data/spark-events
 ENV PATH $SPARK_HOME/bin:$PATH
 # set the python path explicitly because spark looks in the wrong spot by default
 ENV PYTHONPATH `echo "import sys; print ':'.join(sys.path)" | python`:$PYTHONPATH

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,6 +8,9 @@ if [[ "$CMD" == "master" ]]; then
 elif [[ "$CMD" == "worker" ]]; then
   /bin/bash -c "$SPARK_HOME/sbin/start-slave.sh $SPARK_MASTER_URL"
   /bin/bash -c "tail -f $SPARK_HOME/logs/spark--org.apache.spark.deploy.worker.Worker*"
+elif [[ "$CMD" == "history" ]]; then
+  /bin/bash -c "$SPARK_HOME/sbin/start-history-server.sh"
+  /bin/bash -c "tail -f $SPARK_HOME/logs/spark--org.apache.spark.deploy.history.HistoryServer*"
 else
   /bin/bash -c "$*"
 fi

--- a/conf/spark-defaults.conf
+++ b/conf/spark-defaults.conf
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Default system properties included when running spark-submit.
+# This is useful for setting default environmental settings.
+
+# Example:
+ spark.eventLog.enabled           true
+ spark.eventLog.dir               file:/data/spark-events 
+ spark.history.fs.logDirectory    file:/data/spark-events

--- a/deployments/staging/spark-history-controller.json
+++ b/deployments/staging/spark-history-controller.json
@@ -65,8 +65,25 @@
                                 "memory": "1300Mi"
                             }
                         },
+                        "volumeMounts": [
+                          {
+                            "mountPath": "/data/spark-events",
+                            "name": "spark-history-efs"
+                          }
+                        ],
                         "terminationMessagePath": "/dev/termination-log"
                     }
+                ],
+                "imagePullSecrets": {
+                  "name": "spark-pull-secret"
+                },
+                "volumes": [
+                  {
+                    "name": "spark-history-efs",
+                    "persistentVolumeClaim": {
+                      "claimName": "spark-history-efs"
+                    }
+                  }
                 ],
                 "dnsPolicy": "ClusterFirst",
                 "restartPolicy": "Always",

--- a/deployments/staging/spark-history-controller.json
+++ b/deployments/staging/spark-history-controller.json
@@ -1,0 +1,78 @@
+{
+    "apiVersion": "extensions/v1beta1",
+    "kind": "Deployment",
+    "metadata": {
+        "labels": {
+            "component": "spark-history"
+        },
+        "name": "spark-history-controller",
+        "namespace": "spark-cluster"
+    },
+    "spec": {
+        "replicas": 1,
+        "selector": {
+            "matchLabels": {
+                "component": "spark-history"
+            }
+        },
+        "strategy": {
+            "rollingUpdate": {
+                "maxSurge": 1,
+                "maxUnavailable": 1
+            },
+            "type": "RollingUpdate"
+        },
+        "template": {
+            "metadata": {
+                "labels": {
+                    "component": "spark-history"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "args": [
+                            "history"
+                        ],
+                        "image": "quay.io/winkapp/spark-standalone:master",
+                        "imagePullPolicy": "Always",
+                        "livenessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/",
+                                "port": 18080,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 10,
+                            "periodSeconds": 30,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 10
+                        },
+                        "name": "spark-history",
+                        "ports": [
+                            {
+                                "containerPort": 18080,
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {
+                            "limits": {
+                                "cpu": "1",
+                                "memory": "1300Mi"
+                            },
+                            "requests": {
+                                "cpu": "1",
+                                "memory": "1300Mi"
+                            }
+                        },
+                        "terminationMessagePath": "/dev/termination-log"
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "restartPolicy": "Always",
+                "securityContext": {},
+                "terminationGracePeriodSeconds": 30
+            }
+        }
+    }
+}

--- a/deployments/staging/spark-history-service.json
+++ b/deployments/staging/spark-history-service.json
@@ -1,0 +1,23 @@
+{
+    "apiVersion": "v1",
+    "kind": "Service",
+    "metadata": {
+        "name": "history-service",
+        "namespace": "spark-cluster"
+    },
+    "spec": {
+        "clusterIP": "None",
+        "ports": [
+            {
+                "name": "http",
+                "port": 18080,
+                "protocol": "TCP",
+                "targetPort": 18080
+            }
+        ],
+        "selector": {
+            "component": "spark-worker"
+        },
+        "type": "ClusterIP"
+    }
+}

--- a/deployments/staging/spark-history-volume-claim.json
+++ b/deployments/staging/spark-history-volume-claim.json
@@ -1,0 +1,29 @@
+{
+  "kind": "PersistentVolumeClaim",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "spark-history-efs",
+    "namespace": "spark-cluster",
+    "labels": {
+        "environment": "staging",
+        "name": "spark-history-efs"
+    }
+  },
+  "spec": {
+    "selector": {
+        "matchLabels": {
+            "environment": "staging",
+            "name": "spark-history-efs"
+        }
+    },
+    "accessModes": [
+      "ReadWriteMany"
+    ],
+    "storageClassName": "",
+    "resources": {
+      "requests": {
+        "storage": "10Gi"
+      }
+    }
+  }
+}

--- a/deployments/staging/spark-history-volume.json
+++ b/deployments/staging/spark-history-volume.json
@@ -1,0 +1,23 @@
+{
+  "apiVersion": "v1",
+  "kind": "PersistentVolume",
+  "metadata": {
+    "name": "spark-history-efs",
+    "labels": {
+        "environment": "staging",
+        "name": "spark-history-efs"
+    }
+  },
+  "spec": {
+    "capacity": {
+      "storage": "10Gi"
+    },
+    "accessModes": [
+      "ReadWriteMany"
+    ],
+    "nfs": {
+      "server": "fs-b53643fc.efs.us-east-1.amazonaws.com",
+      "path": "/spark/data/spark-events"
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "4040:4040"
     volumes:
-      - ./spark-events:/tmp/spark-events
+      - ./spark-events:/data/spark-events
     links:
       - spark-history
       - spark-worker
@@ -17,7 +17,7 @@ services:
     ports:
       - "18080:18080"
     volumes:
-      - ./spark-events:/tmp/spark-events
+      - ./spark-events:/data/spark-events
   spark-master:
     build: .
     command: /usr/local/bootstrap.sh master

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,23 @@
 version: '2'
 services:
+  spark-repl:
+    build: .
+    command: /usr/local/spark/bin/spark-shell --master spark://spark-master:7077 
+    ports:
+      - "4040:4040"
+    volumes:
+      - ./spark-events:/tmp/spark-events
+    links:
+      - spark-history
+      - spark-worker
+      - spark-master
+  spark-history:
+    build: .
+    command: /usr/local/bootstrap.sh history
+    ports:
+      - "18080:18080"
+    volumes:
+      - ./spark-events:/tmp/spark-events
   spark-master:
     build: .
     command: /usr/local/bootstrap.sh master


### PR DESCRIPTION
modifies image and defines deployments for history server
(some details here --> https://jaceklaskowski.gitbooks.io/mastering-apache-spark/spark-history-server.html)

spark history server works by having the driver nodes stream job progress logs out to json files, indicated where we update defaults with `spark.eventLog.enabled = true` and subsequently setting `spark.eventLog.dir = file:/data/spark-events` - the server then listens on that very same file path and allows us to view any logs stored there.

In most examples, the `eventLog.dir` value used in a distributed cluster points to an `hdfs` filesystem - instead, we plan to take advantage of kubernete's ability to share a `PersistentVolume` across multiple pods, so that we can have drivers write out to a mounted filesystem, and subsequently have a history server mounted and reading in from the same filesystem.

the `eventLog.dir` _is_ created during image build, but here we will need to define `PersistentVolume`, `PersistentVolumeClaim` and a volume mount on both the history server deployments and the driver node deployments that we wish to make accessible.